### PR TITLE
Use the new HashMap API introduced in Zig 0.8.0

### DIFF
--- a/src/svd.zig
+++ b/src/svd.zig
@@ -86,7 +86,7 @@ pub const Device = struct {
         try out_stream.writeAll("pub const interrupts = struct {\n");
         var iter = self.interrupts.iterator();
         while (iter.next()) |entry| {
-            var interrupt = entry.value;
+            var interrupt = entry.value_ptr.*;
             if (interrupt.value) |int_value| {
                 try out_stream.print(
                     "pub const {s} = {};\n",


### PR DESCRIPTION
There was breaking changes in the HashMap APIs in the Zig 0.8.0 release( https://ziglang.org/download/0.8.0/release-notes.html#Hash-Maps ). This change replaces the existing API usage to the new one.