### PR TITLE
Updated to support 0.10.0-dev

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -84,13 +84,13 @@ pub fn main() anyerror!void {
 
     const allocator = arena.allocator();
 
-    var args = std.process.args();
+    var args = try std.process.argsWithAllocator(allocator);
 
-    _ = args.next(allocator); // skip application name
+    _ = args.next(); // skip application name
     // Note memory will be freed on exit since using arena
 
-    const file_name = try args.next(allocator) orelse return error.MandatoryFilenameArgumentNotGiven;
-    const file = try std.fs.cwd().openFile(file_name, .{ .read = true, .write = false });
+    const file_name = try args.next() orelse error.MandatoryFilenameArgumentNotGiven;
+    const file = try std.fs.cwd().openFile(file_name, .{ .mode = .read_only });
 
     const stream = &file.reader();
 


### PR DESCRIPTION
argsWithAllocator() is needed in place of args() for Windows compatibility