### PR TITLE
Fixed arg parsing issues and ignored errors in tests with zig 0.10.1

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -84,14 +84,14 @@ pub fn main() anyerror!void {
 
     const allocator = arena.allocator();
 
-    var args = std.process.args();
+    var args = try std.process.argsWithAllocator(allocator);
 
-    _ = args.next(allocator); // skip application name
+    _ = args.next(); // skip application name
     // Note memory will be freed on exit since using arena
 
-    const file_name = try args.next(allocator) orelse return error.MandatoryFilenameArgumentNotGiven;
-    const file = try std.fs.cwd().openFile(file_name, .{ .read = true, .write = false });
+    const file_name = args.next() orelse return error.MandatoryFilenameArgumentNotGiven;
 
+    const file = try std.fs.cwd().openFile(file_name, .{ .mode = .read_only });
     const stream = &file.reader();
 
     var state = SvdParseState.Device;
@@ -450,27 +450,27 @@ test "getChunk" {
     const expected_chunk = XmlChunk{ .tag = "name", .data = "STM32F7x7", .derivedFrom = null };
 
     const chunk = getChunk(valid_xml).?;
-    std.testing.expectEqualSlices(u8, chunk.tag, expected_chunk.tag);
-    std.testing.expectEqualSlices(u8, chunk.data.?, expected_chunk.data.?);
+    try std.testing.expectEqualSlices(u8, chunk.tag, expected_chunk.tag);
+    try std.testing.expectEqualSlices(u8, chunk.data.?, expected_chunk.data.?);
 
     const no_data_xml = "  <name> \n";
     const expected_no_data_chunk = XmlChunk{ .tag = "name", .data = null, .derivedFrom = null };
     const no_data_chunk = getChunk(no_data_xml).?;
-    std.testing.expectEqualSlices(u8, no_data_chunk.tag, expected_no_data_chunk.tag);
-    std.testing.expectEqual(no_data_chunk.data, expected_no_data_chunk.data);
+    try std.testing.expectEqualSlices(u8, no_data_chunk.tag, expected_no_data_chunk.tag);
+    try std.testing.expectEqual(no_data_chunk.data, expected_no_data_chunk.data);
 
     const comments_xml = "<description>Auxiliary Cache Control register</description>";
     const expected_comments_chunk = XmlChunk{ .tag = "description", .data = "Auxiliary Cache Control register", .derivedFrom = null };
     const comments_chunk = getChunk(comments_xml).?;
-    std.testing.expectEqualSlices(u8, comments_chunk.tag, expected_comments_chunk.tag);
-    std.testing.expectEqualSlices(u8, comments_chunk.data.?, expected_comments_chunk.data.?);
+    try std.testing.expectEqualSlices(u8, comments_chunk.tag, expected_comments_chunk.tag);
+    try std.testing.expectEqualSlices(u8, comments_chunk.data.?, expected_comments_chunk.data.?);
 
     const derived = "   <peripheral derivedFrom=\"TIM10\">";
     const expected_derived_chunk = XmlChunk{ .tag = "peripheral", .data = null, .derivedFrom = "TIM10" };
     const derived_chunk = getChunk(derived).?;
-    std.testing.expectEqualSlices(u8, derived_chunk.tag, expected_derived_chunk.tag);
-    std.testing.expectEqualSlices(u8, derived_chunk.derivedFrom.?, expected_derived_chunk.derivedFrom.?);
-    std.testing.expectEqual(derived_chunk.data, expected_derived_chunk.data);
+    try std.testing.expectEqualSlices(u8, derived_chunk.tag, expected_derived_chunk.tag);
+    try std.testing.expectEqualSlices(u8, derived_chunk.derivedFrom.?, expected_derived_chunk.derivedFrom.?);
+    try std.testing.expectEqual(derived_chunk.data, expected_derived_chunk.data);
 }
 
 fn textToBool(data: []const u8) ?bool {

--- a/src/svd.zig
+++ b/src/svd.zig
@@ -634,7 +634,7 @@ test "Field print" {
     field.bit_width = 1;
 
     try buf_stream.print("{}\n", .{field});
-    std.testing.expect(std.mem.eql(u8, output_buffer.items, fieldDesiredPrint));
+    try std.testing.expect(std.mem.eql(u8, output_buffer.items, fieldDesiredPrint));
 }
 
 test "Register Print" {
@@ -697,7 +697,7 @@ test "Register Print" {
     try register.fields.append(field2);
 
     try buf_stream.print("{}\n", .{register});
-    std.testing.expectEqualSlices(u8, output_buffer.items, registerDesiredPrint);
+    try std.testing.expectEqualSlices(u8, output_buffer.items, registerDesiredPrint);
 }
 
 test "Peripheral Print" {
@@ -773,7 +773,7 @@ test "Peripheral Print" {
     try peripheral.registers.append(register);
 
     try buf_stream.print("{}\n", .{peripheral});
-    std.testing.expectEqualSlices(u8, peripheralDesiredPrint, output_buffer.items);
+    try std.testing.expectEqualSlices(u8, peripheralDesiredPrint, output_buffer.items);
 }
 fn bitWidthToMask(width: u32) u32 {
     const max_supported_bits = 32;


### PR DESCRIPTION
Hello, 

I've worked on handling the missing file argument error that I found when using `zig` 0.10.1. Hoping this helps and was done correctly.

I also added `try` in front of the tests in `main.zig` because when running `zig test ./src/main.zig` I received `error: error is ignored` errors.

Cheers,
-A.